### PR TITLE
tomcat version update and fix for sidescroll on index page

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 <project name="TomcatSetup" default="start-webapp" basedir=".">
     <property name="build.dir" value="build"/>
     <property name="download.dir" value="download"/>
-    <property name="tomcat.version" value="9.0.83"/>
+    <property name="tomcat.version" value="9.0.85"/>
     <property name="tomcat.url"
               value="https://downloads.apache.org/tomcat/tomcat-9/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip"/>
     <property name="tomcat.home" value="${build.dir}/apache-tomcat-${tomcat.version}"/>

--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -89,7 +89,6 @@ textarea::placeholder {
     bottom: 0;
     left: 0;
     background-color: #d3d3d3;
-    width: 100%;
     height: auto;
     margin-top: auto;
 }


### PR DESCRIPTION
tomcat version got updated to 85 since 83 no longer exists and the width of the disclaimer element has been fixed so that it does not scroll sideways anymore