### PR TITLE
changed the storage type to database instead of memory

### DIFF
--- a/src/main/resources/springTestToolTestWebapp.xml
+++ b/src/main/resources/springTestToolTestWebapp.xml
@@ -140,11 +140,11 @@
 
 	<!-- Use memory storage by default as Cypress tests depend on memory storage / starting with empty storages -->
 
-	<bean name="debugStorage" class="nl.nn.testtool.storage.memory.Storage" autowire="byName">
+	<bean name="debugStorage" class="nl.nn.testtool.storage.database.DatabaseStorage" autowire="byName">
 		<property name="name" value="Debug"/>
 	</bean>
 
-	<bean name="testStorage" class="nl.nn.testtool.storage.memory.Storage" autowire="byName">
+	<bean name="testStorage" class="nl.nn.testtool.storage.database.DatabaseStorage" autowire="byName">
 		<property name="name" value="Test"/>
 	</bean>
 


### PR DESCRIPTION
By changing the storage type to database, reports will now be saved even if the server restarts and reports will also show in the right order now.

Instead of sorting the reports by storageId ascending, it is now sorting the reports by storageId descending.