### PR TITLE
Update xslt-debugger to nexus version 1.0-20240403.121259-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.wearefrank</groupId>
             <artifactId>xslt-debugger</artifactId>
-            <version>1.0-20240207.095015-1</version>
+            <version>1.0-20240403.121259-3</version>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>


### PR DESCRIPTION
updated was based on PR #26 and #27 from the xslt-debugger repo.